### PR TITLE
configure workflow starter meta and icon

### DIFF
--- a/workflow-templates/close-empty-issues-icon.svg
+++ b/workflow-templates/close-empty-issues-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
+  <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
+  <path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
+</svg>

--- a/workflow-templates/close-empty-issues.properties.json
+++ b/workflow-templates/close-empty-issues.properties.json
@@ -1,0 +1,8 @@
+{
+  "name": "AutoClose Empty Issues Workflow",
+  "description": "Workflow to automatically close issues that don't contain any body content.",
+  "iconName": "close-empty-issues-icon",
+  "categories": [
+      "Issues"
+  ]
+}

--- a/workflow-templates/close-empty-issues.yml
+++ b/workflow-templates/close-empty-issues.yml
@@ -1,7 +1,7 @@
 # This workflow automatically closes issues that contain an empty body.
 # For more information, see:
 # https://github.com/kerhub/saved-replies
-name: Auto close empty issues
+name: AutoClose Empty Issues Workflow
 on:
   issues:
     types: [opened]


### PR DESCRIPTION
Fixes missing meta information required for starter-workflows to be detected by github.

## Proposed Changes

  - Add meta information to the `close-stale-issues-and-pr`  as well.
  -
  -